### PR TITLE
add overflow to app root

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -12,6 +12,8 @@
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-text-size-adjust: 100%;
+
+	overflow: hidden;
 }
 
 a {


### PR DESCRIPTION
Prevents Scroll bars from displaying at the root level